### PR TITLE
Allow setting an error handler

### DIFF
--- a/phpiredis.c
+++ b/phpiredis.c
@@ -182,7 +182,6 @@ PHP_FUNCTION(phpiredis_multi_command)
     zval **tmp;
     HashPosition pos;
     zval *resource;
-    redisReply *reply;
     phpiredis_connection *connection;
     zval *arr;
     zval **arg2;
@@ -212,7 +211,7 @@ PHP_FUNCTION(phpiredis_multi_command)
 
     array_init(return_value);
     for (i = 0; i < commands; ++i) {
-        redisReply *reply;
+        redisReply *reply = NULL;
         zval* result;
         MAKE_STD_ZVAL(result);
 
@@ -220,6 +219,9 @@ PHP_FUNCTION(phpiredis_multi_command)
             for (; i < commands; ++i) {
                 add_index_bool(return_value, i, 0);
             }
+
+            if (reply) freeReplyObject(reply);
+
             efree(result);
             break;
         }
@@ -237,7 +239,6 @@ PHP_FUNCTION(phpiredis_multi_command_bs)
     HashPosition cmdsPos;
     HashPosition cmdArgsPos;
     zval *resource;
-    redisReply *reply;
     phpiredis_connection *connection;
     zval *cmds;
     zval cmdArgs;
@@ -299,7 +300,7 @@ PHP_FUNCTION(phpiredis_multi_command_bs)
 
     array_init(return_value);
     for (i = 0; i < commands; ++i) {
-        redisReply *reply;
+        redisReply *reply = NULL;
         zval* result;
         MAKE_STD_ZVAL(result);
 
@@ -307,6 +308,9 @@ PHP_FUNCTION(phpiredis_multi_command_bs)
             for (; i < commands; ++i) {
                 add_index_bool(return_value, i, 0);
             }
+
+            if (reply) freeReplyObject(reply);
+
             efree(result);
             break;
         }
@@ -351,7 +355,7 @@ PHP_FUNCTION(phpiredis_command)
 PHP_FUNCTION(phpiredis_command_bs)
 {
     zval *resource;
-    redisReply *reply;
+    redisReply *reply = NULL;
     phpiredis_connection *connection;
     zval *params;
     int argc;
@@ -414,7 +418,8 @@ PHP_FUNCTION(phpiredis_command_bs)
     efree(argvlen);
 
     if (redisGetReply(connection->c, &reply) != REDIS_OK) {
-        freeReplyObject(reply);
+        // only free if the reply was actually created
+        if (reply) freeReplyObject(reply);
 
         RETURN_FALSE;
     }


### PR DESCRIPTION
This changeset introduces phpiredis_set_error_handler(), which allows a user to register a PHP callable as an error handler. This handler is called when an error is encountered in the communication with the Redis server. It should correspond to the following signature: function ($errorType, $errorMessage)

$errorType is one of PHPIREDIS_ERROR_CONNECTION and PHPIREDIS_ERROR_PROTOCOL, $errorMessage is just the message as a string.

I am already opening this pull request to get some input as to whether this approach is fine for everyone. Also my C isn't the best, so please let me know if there is a mistake somewhere.

Still left to do:
- Call the error handler in phpiredis_multi_command_*() as well.
- Call the error handler for connection errors as well.
- Maybe pass the returned value from the error handler back?
