### PR TITLE
connection with timeout option

### DIFF
--- a/phpiredis.c
+++ b/phpiredis.c
@@ -68,7 +68,7 @@ void php_redis_reader_dtor(zend_rsrc_list_entry *rsrc TSRMLS_DC)
 }
 
 static
-phpiredis_connection *s_create_connection (const char *ip, int port, zend_bool is_persistent)
+phpiredis_connection *s_create_connection (const char *ip, int port, zend_bool is_persistent, int timeout)
 {
     redisContext *c;
     phpiredis_connection *connection;
@@ -78,7 +78,15 @@ phpiredis_connection *s_create_connection (const char *ip, int port, zend_bool i
         // starts with a slash character indicating a UNIX domain socket path.
         c = redisConnectUnix(ip);
     } else {
-        c = redisConnect(ip, port);
+        if (timeout) {
+            // timeout is in millisecond
+            int timeout_sec = timeout/1000;
+            int timeout_usec = (timeout%1000)*1000;
+            struct timeval tv = { timeout_sec, timeout_usec };
+            c = redisConnectWithTimeout(ip, port, tv);
+        } else {
+            c = redisConnect(ip, port);
+        }
     }
 
     if (!c || c->err) {
@@ -101,12 +109,13 @@ PHP_FUNCTION(phpiredis_connect)
     char *ip;
     int ip_size;
     long port = 6379;
+    long timeout = 0;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|l", &ip, &ip_size, &port) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &ip, &ip_size, &port, &timeout) == FAILURE) {
         return;
     }
 
-    connection = s_create_connection(ip, port, 0);
+    connection = s_create_connection(ip, port, 0, timeout);
 
     if (!connection) {
         RETURN_FALSE;
@@ -120,6 +129,7 @@ PHP_FUNCTION(phpiredis_pconnect)
     char *ip;
     int ip_size;
     long port = 6379;
+    long timeout = 0;
 
     char *hashed_details = NULL;
     int hashed_details_length;
@@ -127,7 +137,7 @@ PHP_FUNCTION(phpiredis_pconnect)
 
     zend_rsrc_list_entry new_le, *le;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|l", &ip, &ip_size, &port) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ll", &ip, &ip_size, &port, &timeout) == FAILURE) {
         return;
     }
 
@@ -146,7 +156,7 @@ PHP_FUNCTION(phpiredis_pconnect)
         return;
     }
 
-    connection = s_create_connection(ip, port, 1);
+    connection = s_create_connection(ip, port, 1, timeout);
 
     if (!connection) {
         efree(hashed_details);

--- a/phpiredis.c
+++ b/phpiredis.c
@@ -76,7 +76,15 @@ phpiredis_connection *s_create_connection (const char *ip, int port, zend_bool i
     if (ip[0] == '/') {
         // We simply ignore the value of "port" if the string value in "ip"
         // starts with a slash character indicating a UNIX domain socket path.
-        c = redisConnectUnix(ip);
+        if (timeout) {
+            // timeout is in millisecond
+            int timeout_sec = timeout/1000;
+            int timeout_usec = (timeout%1000)*1000;
+            struct timeval tv = { timeout_sec, timeout_usec };
+            c = redisConnectUnixWithTimeout(ip, tv);
+        } else {
+            c = redisConnectUnix(ip);
+        }
     } else {
         if (timeout) {
             // timeout is in millisecond

--- a/tests/client_003.phpt
+++ b/tests/client_003.phpt
@@ -16,6 +16,7 @@ require_once 'testsuite_utilities.inc';
 create_phpiredis_connection(REDIS_UNIX_SOCKET, 9999);
 create_phpiredis_connection(REDIS_UNIX_SOCKET, NULL);
 create_phpiredis_connection(REDIS_UNIX_SOCKET, NULL, TRUE);
+create_phpiredis_connection(REDIS_UNIX_SOCKET, NULL, TRUE, 1000);
 
 echo "OK" . PHP_EOL;
 

--- a/tests/client_012.phpt
+++ b/tests/client_012.phpt
@@ -1,0 +1,16 @@
+--TEST--
+[CLIENT] Connect to Redis with timeout
+
+--SKIPIF--
+<?php
+require_once 'testsuite_skipif.inc';
+
+--FILE--
+<?php
+require_once 'testsuite_utilities.inc';
+
+$redis = create_phpiredis_connection(REDIS_HOST, REDIS_PORT, false, 1000);
+var_dump($redis);
+
+--EXPECTF--
+resource(%d) of type (phpredis connection)

--- a/tests/client_013.phpt
+++ b/tests/client_013.phpt
@@ -9,7 +9,7 @@ require_once 'testsuite_skipif.inc';
 <?php
 require_once 'testsuite_utilities.inc';
 
-$redis = create_phpiredis_connection('169.254.10.10', REDIS_PORT, false, 200);
+$redis = create_phpiredis_connection('169.254.10.10', REDIS_PORT, true, 200);
 usleep(500000);
 
 --EXPECTF--

--- a/tests/testsuite_utilities.inc
+++ b/tests/testsuite_utilities.inc
@@ -3,13 +3,21 @@
 require_once 'testsuite_configuration.inc';
 
 if (!function_exists('create_phpiredis_connection')) {
-    function create_phpiredis_connection($host, $port = 6379, $persistent = false) {
+    function create_phpiredis_connection($host, $port = 6379, $persistent = false, $timeout = false) {
         global $connect_flags;
 
         if ($persistent) {
-            $link = phpiredis_pconnect($host, $port);
+            if ($timeout) {
+                $link = phpiredis_pconnect($host, $port, $timeout);
+            } else {
+                $link = phpiredis_pconnect($host, $port);
+            }
         } else {
-            $link = phpiredis_connect($host, $port);
+            if ($timeout) {
+                $link = phpiredis_connect($host, $port, $timeout);
+            } else {
+                $link = phpiredis_connect($host, $port);
+            }
         }
 
         if (!$link) {


### PR DESCRIPTION
About this https://github.com/nrk/phpiredis/issues/31

New option when you create a phpredis_connect
phpiredis_connect($ip [, int $port, int $timeout ] );
$timeout is optionnal and is in millisecond
It's work with phpiredis_pconnect too.

example:
phpiredis_connect('127.0.0.1' , 6379, 20 );
