### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Building and using this extension requires `hiredis` (>=0.9.0 <1.0.0) to be inst
 `hiredis` is usually available in the repositories of most Linux distributions, alternatively it is
 possible to build it by fetching the code from its [repository](https://github.com/redis/hiredis).
 
+`Note`: Installing the phpiredis extension requires php to install both the APC and APCU extensions, 
+otherwise the dynamic library cannot be loaded.
+
 ```sh
 git clone https://github.com/nrk/phpiredis.git
 cd phpiredis


### PR DESCRIPTION

Note: Installing the phpiredis extension requires php to install both the APC and APCU extensions in addition to Hiredis, otherwise the dynamic library cannot be loaded. Many developers in the installation process will appear the following errors, some solve the problem for a few days can not find the reason, in fact, php parsing phpiredis is the need to rely on apc and acpu extension, phpiredis compilation is also the need for the library of hiredis.
```bash
[root@localhost /data/wwwroot/code/_example/app]#php index.php
PHP Fatal error:  Call to undefined function phpiredis_connect() in /data/wwwroot/code/library/includes/class/memcachedb.php on line 75
```