### PR TITLE
changed all commands from redisReplyReader to redisReader

### DIFF
--- a/phpiredis.c
+++ b/phpiredis.c
@@ -303,7 +303,7 @@ static void php_redis_reader_dtor(PHPIREDIS_RESOURCE_TYPE *rsrc TSRMLS_DC)
         }
 
         if (reader->reader != NULL) {
-            redisReplyReaderFree(reader->reader);
+            redisReaderFree(reader->reader);
         }
 
         free_reader_status_callback(reader TSRMLS_CC);
@@ -733,7 +733,7 @@ PHP_FUNCTION(phpiredis_reader_create)
     }
 
     reader = emalloc(sizeof(phpiredis_reader));
-    reader->reader = redisReplyReaderCreate();
+    reader->reader = redisReaderCreate();
     reader->error = NULL;
     reader->bufferedReply = NULL;
     reader->status_callback = NULL;
@@ -826,10 +826,10 @@ PHP_FUNCTION(phpiredis_reader_reset)
     }
 
     if (reader->reader != NULL) {
-        redisReplyReaderFree(reader->reader);
+        redisReaderFree(reader->reader);
     }
 
-    reader->reader = redisReplyReaderCreate();
+    reader->reader = redisReaderCreate();
 }
 
 PHP_FUNCTION(phpiredis_reader_destroy)
@@ -876,7 +876,7 @@ PHP_FUNCTION(phpiredis_reader_feed)
         RETURN_FALSE;
     }
 
-    redisReplyReaderFeed(reader->reader, bytes, size);
+    redisReaderFeed(reader->reader, bytes, size);
 }
 
 PHP_FUNCTION(phpiredis_reader_get_error)
@@ -928,11 +928,11 @@ PHP_FUNCTION(phpiredis_reader_get_reply)
         aux = reader->bufferedReply;
         reader->bufferedReply = NULL;
     } else {
-        if (redisReplyReaderGetReply(reader->reader, (void **)&aux) == REDIS_ERR) {
+        if (redisReaderGetReply(reader->reader, (void **)&aux) == REDIS_ERR) {
             if (reader->error != NULL) {
                 efree(reader->error);
             }
-            reader->error = redisReplyReaderGetError(reader->reader);
+            reader->error = redisReaderGetError(reader->reader);
 
             RETURN_FALSE; // error
         } else if (aux == NULL) {
@@ -967,11 +967,11 @@ PHP_FUNCTION(phpiredis_reader_get_state)
     if (reader->error == NULL && reader->bufferedReply == NULL) {
         void *aux;
 
-        if (redisReplyReaderGetReply(reader->reader, &aux) == REDIS_ERR) {
+        if (redisReaderGetReply(reader->reader, &aux) == REDIS_ERR) {
             if (reader->error != NULL) {
                 efree(reader->error);
             }
-            reader->error = redisReplyReaderGetError(reader->reader);
+            reader->error = redisReaderGetError(reader->reader);
         } else {
             reader->bufferedReply = aux;
         }


### PR DESCRIPTION
I was reading through the hiredis documents and see that the main change to 0.14.0 from 0.13.3 is that some commands were changed from redisReplyReader* to redisReader*. I made this simple change to the *.c file, compiled it for armv7h, installed hiredis 0.14.0, installed the compiled php-phpiredis-git and now it works. I was reading through the docs for the upcoming updates and do not think I know enough to adapt this to the upcoming hiredis 1.0.0 as there are more changes that I do not fully understand, so I may not be able to help on the next update, but for now, this seems to work. 
[https://github.com/redis/hiredis/blob/master/CHANGELOG.md](url)