### PR TITLE
fix for upcoming PHP 8

### DIFF
--- a/phpiredis.c
+++ b/phpiredis.c
@@ -28,6 +28,11 @@ int le_redis_persistent_context;
     typedef long zend_long;
 #endif
 
+#ifndef TSRMLS_CC
+#define TSRMLS_CC
+#define TSRMLS_DC
+#endif
+
 typedef struct callback {
 #ifdef ZEND_ENGINE_3
     zval function;


### PR DESCRIPTION
TSRM_* macros are no more needed with PHP 7, and have been removed in PHP 8

Notice: other way is to drop compat with PHP 5 and remove all their usage.

```
=====================================================================
PHP         : /opt/remi/php80/root/usr/bin/php 
PHP_SAPI    : cli
PHP_VERSION : 8.0.0beta2
ZEND_VERSION: 4.0.0-dev
...
=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   16
---------------------------------------------------------------------

Number of tests :   27                26
Tests skipped   :    1 (  3.7%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :   26 ( 96.3%) (100.0%)
---------------------------------------------------------------------
Time taken      :    0 seconds
=====================================================================
```
