### PR TITLE
fix build with hiredis >= 0.14

### DIFF
--- a/phpiredis.c
+++ b/phpiredis.c
@@ -33,6 +33,14 @@ int le_redis_persistent_context;
 #define TSRMLS_DC
 #endif
 
+#if HIREDIS_MAJOR > 0 || HIREDIS_MINOR >= 14
+#define redisReplyReaderGetReply redisReaderGetReply
+#define redisReplyReaderFeed     redisReaderFeed
+#define redisReplyReaderGetError redisReaderGetError
+#define redisReplyReaderFree     redisReaderFree
+#define redisReplyReaderCreate   redisReaderCreate
+#endif
+
 typedef struct callback {
 #ifdef ZEND_ENGINE_3
     zval function;


### PR DESCRIPTION
While Fedora, RHEL/CentOS have 0.13
Fedora 36 and RHEL/CentOS 9 will have 1.0.2

This trivial patch allow to build v1.0 using this newer version (test suite passes with 0.14.1 or 1.0.2)